### PR TITLE
Fall back to keyboard input when speech recognition is not available

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -3054,6 +3054,10 @@ input {
   width: 50%;
   background: transparent;
 }
+input::placeholder {
+  font-size: 75%;
+  color: #CCCCCC;
+}
 textarea {
   display: block;
   margin: 0 auto;

--- a/src/components/toolbar.js
+++ b/src/components/toolbar.js
@@ -4,6 +4,8 @@ import { observer } from 'mobx-react';
 export default observer(({ recognizer, sam }) => {
   const { listening, transcript } = recognizer;
   const className = `icon-base ${listening ? 'animated pulse infinite icon-mysam-icon' : 'icon-microphone'}`;
+  const startRecognition = () => recognizer.toggle()
+    .catch(error => sam.runAction('input', { error }));
 
   return <header>
     <div className='padded'>
@@ -17,7 +19,7 @@ export default observer(({ recognizer, sam }) => {
       <div className='pull-right'>
         <small>{transcript.text}</small>
 
-        <button onClick={() => recognizer.toggle()}
+        <button onClick={startRecognition}
           className={className} />
         <button className='round-button small' onClick={() => sam.runAction('input')}>
           <i className='fa fa-keyboard-o' aria-hidden='true' />

--- a/src/plugins/input.js
+++ b/src/plugins/input.js
@@ -13,14 +13,15 @@ class InputForm extends React.Component {
 
   render () {
     return <form className='animated fadeIn' onSubmit={this.submit.bind(this)}>
-      <input type='text' />
+      {this.props.classification.error && <h1>Oh no! I can't hear you but we can still chat</h1>}
+      <input type='text' placeholder='Type here and confirm with enter or by clicking the button' />
       <button style={{ marginLeft: '10px' }} className='icon-base icon-checkmark' type='submit' />
     </form>;
   }
 }
 
 export default function (sam) {
-  sam.action('input', function (el, classification) {
-    return sam.render(<InputForm classify={sam.classify.bind(sam)} />, el);
+  sam.action('input', function (el, classification = {}) {
+    return sam.render(<InputForm classification={classification} classify={sam.classify.bind(sam)} />, el);
   });
 }

--- a/src/recognizer.js
+++ b/src/recognizer.js
@@ -84,9 +84,6 @@ export default class Recognizer extends EventEmitter {
 
       debug('Starting recognition');
 
-      this.listening = false;
-      this.recognition.start();
-
       this.once('transcript', transcript => {
         if (transcript.isFinal) {
           debug('Got final transcript', transcript);
@@ -97,6 +94,9 @@ export default class Recognizer extends EventEmitter {
       });
 
       this.once('error', onError);
+
+      this.listening = false;
+      this.recognition.start();
     });
   }
 

--- a/styles/styles.less
+++ b/styles/styles.less
@@ -179,6 +179,11 @@ input {
   text-align: center;
   width: 50%;
   background: transparent;
+
+  &::placeholder {
+    font-size: 75%;
+    color: @brand-color-4;
+  }
 }
 
 textarea {


### PR DESCRIPTION
Most browser hide speech recognition behind a flag or do not support it at all. This PR makes the UI fall back to the keyboard input if starting speech recognition failed.

<img width="1223" alt="screen shot 2018-01-14 at 12 04 09 pm" src="https://user-images.githubusercontent.com/338316/34920167-3d11ac72-f923-11e7-81ee-7f643226fd99.png">

